### PR TITLE
refactor(fastapi): use gather for concurrent DB requests

### DIFF
--- a/frameworks/Python/fastapi/README.md
+++ b/frameworks/Python/fastapi/README.md
@@ -32,6 +32,8 @@ All of the test implementations are located within a single file ([app.py](app.p
 
 All the tests are based on the ones for Starlette, as FastAPI is basically Starlette on steroids plus Pydantic, with many features specifically desgined for API development. All this while still supporting all the other features provided by Starlette.
 
+Tests should use async features like `asyncio.gather` when possible.
+
 ## Resources
 
 * [FastAPI source code on GitHub](https://github.com/tiangolo/fastapi)

--- a/frameworks/Python/fastapi/app.py
+++ b/frameworks/Python/fastapi/app.py
@@ -61,13 +61,11 @@ async def single_database_query():
 async def multiple_database_queries(queries = None):
     num_queries = get_num_queries(queries)
     row_ids = sample(range(1, 10000), num_queries)
-    worlds = []
 
     async with connection_pool.acquire() as connection:
         statement = await connection.prepare(READ_ROW_SQL)
-        for row_id in row_ids:
-            number = await statement.fetchval(row_id)
-            worlds.append({"id": row_id, "randomNumber": number})
+        numbers = await asyncio.gather(*[statement.fetchval(row_id) for row_id in row_ids])
+    worlds = [{"id": row_id, "randomNumber": number} for row_id, number in zip(row_ids, numbers)]
 
     return JSONResponse(worlds)
 
@@ -90,8 +88,7 @@ async def database_updates(queries = None):
 
     async with connection_pool.acquire() as connection:
         statement = await connection.prepare(READ_ROW_SQL)
-        for row_id, number in updates:
-            await statement.fetchval(row_id)
+        await asyncio.gather(*[statement.fetchval(row_id) for row_id, number in updates])
         await connection.executemany(WRITE_ROW_SQL, updates)
 
     return JSONResponse(worlds)

--- a/frameworks/Python/fastapi/app.py
+++ b/frameworks/Python/fastapi/app.py
@@ -40,6 +40,7 @@ async def setup_database():
         database="hello_world",
         host="tfb-database",
         port=5432,
+        max_size = 250,
     )
 
 

--- a/frameworks/Python/fastapi/app_orjson.py
+++ b/frameworks/Python/fastapi/app_orjson.py
@@ -61,11 +61,13 @@ async def single_database_query():
 async def multiple_database_queries(queries = None):
     num_queries = get_num_queries(queries)
     row_ids = sample(range(1, 10000), num_queries)
+    worlds = []
 
     async with connection_pool.acquire() as connection:
         statement = await connection.prepare(READ_ROW_SQL)
-        numbers = await asyncio.gather(*[statement.fetchval(row_id) for row_id in row_ids])
-    worlds = [{"id": row_id, "randomNumber": number} for row_id, number in zip(row_ids, numbers)]
+        for row_id in row_ids:
+            number = await statement.fetchval(row_id)
+            worlds.append({"id": row_id, "randomNumber": number})
 
     return ORJSONResponse(worlds)
 
@@ -88,7 +90,8 @@ async def database_updates(queries = None):
 
     async with connection_pool.acquire() as connection:
         statement = await connection.prepare(READ_ROW_SQL)
-        await asyncio.gather(*[statement.fetchval(row_id) for row_id, number in updates])
+        for row_id, number in updates:
+            await statement.fetchval(row_id)
         await connection.executemany(WRITE_ROW_SQL, updates)
 
     return ORJSONResponse(worlds)

--- a/frameworks/Python/fastapi/app_orjson.py
+++ b/frameworks/Python/fastapi/app_orjson.py
@@ -40,6 +40,7 @@ async def setup_database():
         database="hello_world",
         host="tfb-database",
         port=5432,
+        max_size = 250,
     )
 
 


### PR DESCRIPTION
Other frameworks like express do all fetches in parallel, which is where async code should shine.

<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.github/workflows/build.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
